### PR TITLE
Documentation Build Flags

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -25,20 +25,47 @@ verify_prereqs() {
     done
 }
 
+################################################################################
+backup_html() {
+    # Remove and replace existing html-bkp dir
+    echo "Backing up html to html-bkp"
+    rm -rf html-bkp
+    mv html html-bkp
+}
+
+################################################################################
 main() {
+    for i in "$1"
+    do
+        case "$1" in
+            -h|--help)
+                echo "options:"
+                echo "-h, --help    show brief help"
+                echo "-b, --backup  backup html directory"
+                echo ""
+                exit 0;
+                ;;
+            -b|--backup)
+                backup_html
+                shift
+                ;;
+        esac
+    done
+
     set -e
 
     verify_prereqs
     cddocs
 
-    echo "Building Documentation in $PWD"
-    git rm -rf html
+    echo "Building Documentation in $PWD";
+    git rm -rf --ignore-unmatch html
     make html
     mv build/html .
     git add html
     echo "All done!"
 }
 
-main
+
+main $*
 
 # vim: ts=4 sts=4 sw=4 expandtab


### PR DESCRIPTION
Within docs the build-docs.sh has been updated to include two optional terminal flags.
Those being -h|--help for full options list and -b|--backup to retain a copy of the generated html folder.
